### PR TITLE
Added support for dynamic keys in CSV output

### DIFF
--- a/examples/bugtest.py
+++ b/examples/bugtest.py
@@ -1,0 +1,31 @@
+"""Test for issue #45."""
+import dowel
+from dowel import logger, tabular
+
+logger.add_output(dowel.StdOutput())
+logger.add_output(dowel.CsvOutput('out.csv'))
+logger.add_output(dowel.TensorBoardOutput('tensorboard_logdir'))
+
+logger.log('Starting up...')
+for i in range(5):
+    logger.push_prefix('itr {} '.format(i))
+    logger.log('Running training step')
+
+    tabular.record('itr', i)
+    tabular.record('loss', 100.0 / (2 + i))
+
+    # the addition of new data to tabular breaks logging to CSV
+    if i > 0:
+        tabular.record('new_data', i)
+    if i > 1:
+        tabular.record('new_data1', i + 1)
+    if i == 2 or i == 3:
+        tabular.record('new_data2', i * 10)
+
+    logger.log(tabular)
+    tabular.delete_all()
+
+    logger.pop_prefix()
+    logger.dump_all()
+
+logger.remove_all()

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -14,7 +14,8 @@ class CsvOutput(FileOutput):
     """
 
     def __init__(self, file_name):
-        super().__init__(file_name)
+        super().__init__(file_name,
+                         mode='w+')  # opens a new file for reading and writing
         self._writer = None
         self._fieldnames = None
         self._warned_once = set()
@@ -28,33 +29,72 @@ class CsvOutput(FileOutput):
     def record(self, data, prefix=''):
         """Log tabular data to CSV."""
         if isinstance(data, TabularInput):
-            to_csv = data.as_primitive_dict
+            datadict = data.as_primitive_dict
 
-            if not to_csv.keys() and not self._writer:
+            if not datadict.keys() and not self._writer:
                 return
 
+            # If its the first call to record, then write header
             if not self._writer:
-                self._fieldnames = set(to_csv.keys())
-                self._writer = csv.DictWriter(
-                    self._log_file,
-                    fieldnames=self._fieldnames,
-                    extrasaction='ignore')
+                self._fieldnames = set(datadict.keys())
+                self._writer = csv.DictWriter(self._log_file,
+                                              fieldnames=self._fieldnames,
+                                              extrasaction='ignore')
                 self._writer.writeheader()
 
-            if to_csv.keys() != self._fieldnames:
-                self._warn('Inconsistent TabularInput keys detected. '
-                           'CsvOutput keys: {}. '
-                           'TabularInput keys: {}. '
-                           'Did you change key sets after your first '
-                           'logger.log(TabularInput)?'.format(
-                               set(self._fieldnames), set(to_csv.keys())))
+            # If new keys are added, then add extra columns to the csv file
+            if not self._fieldnames.issuperset(datadict.keys()):
+                self.rewriteCSV(datadict.keys())
 
-            self._writer.writerow(to_csv)
+            # If any key is not present in the latest row,
+            # add a blank key-value pair
+            for key in self._fieldnames:
+                if key not in datadict:
+                    datadict[key] = ''
+            self._writer.writerow(datadict)
 
-            for k in to_csv.keys():
+            for k in datadict.keys():
                 data.mark(k)
         else:
             raise ValueError('Unacceptable type.')
+
+    def rewriteCSV(self, fieldnames):
+        """Rewrite the CSV file to accommodate the extra fieldnames.
+
+        This function will read the file, store the data,
+        and rewrite it back to the file after adding the
+        additional fields to all the entries.
+        The value of this column will be blank in these cells
+
+        :param fieldnames: The new set of fieldnames
+        """
+        # read data from file into a list
+        self._log_file.seek(0)
+        csv_reader = csv.DictReader(self._log_file)
+        csvdata = [row for row in csv_reader]
+
+        # clearing the file
+        self._log_file.truncate(0)
+        self._log_file.seek(0)
+
+        # output data back to the file with extra fields
+        for key in fieldnames:
+            if key not in self._fieldnames:
+                self._fieldnames.add(key)
+
+        self._writer = csv.DictWriter(self._log_file,
+                                      fieldnames=self._fieldnames,
+                                      extrasaction='ignore')
+
+        self._writer.writeheader()
+        for row in csvdata:
+            # There are keys which are not set in the current tabular record
+            # Setting them to blank
+            for curfield in self._fieldnames:
+                if curfield not in row:
+                    row[curfield] = ''
+
+            self._writer.writerow(row)
 
     def _warn(self, msg):
         """Warns the user using warnings.warn.
@@ -63,8 +103,9 @@ class CsvOutput(FileOutput):
         is the one printed.
         """
         if not self._disable_warnings and msg not in self._warned_once:
-            warnings.warn(
-                colorize(msg, 'yellow'), CsvOutputWarning, stacklevel=3)
+            warnings.warn(colorize(msg, 'yellow'),
+                          CsvOutputWarning,
+                          stacklevel=3)
         self._warned_once.add(msg)
         return msg
 

--- a/src/dowel/tabular_input.py
+++ b/src/dowel/tabular_input.py
@@ -36,9 +36,13 @@ class TabularInput:
         self._dict[self._prefix_str + str(key)] = val
 
     def delete_key(self, key):
+        """Deletes a key.
+        In the next call to log, if this key is not present
+        then it wouldn't get logged"""
         self._dict.pop(self._prefix_str + str(key))
 
     def delete_all(self):
+        """Deletes all keys"""
         self._dict = {}
 
     def mark(self, key):

--- a/src/dowel/tabular_input.py
+++ b/src/dowel/tabular_input.py
@@ -35,6 +35,12 @@ class TabularInput:
         """
         self._dict[self._prefix_str + str(key)] = val
 
+    def delete_key(self, key):
+        self._dict.pop(self._prefix_str + str(key))
+
+    def delete_all(self):
+        self._dict = {}
+
     def mark(self, key):
         """Mark key as recorded."""
         self._recorded.add(key)


### PR DESCRIPTION
Fixes #45
Solved the issue by rewriting the CSV file if a new key was added. Any cell which doesn't have a value was defaulted to blank. 

The rewriteCSV function reads the file into a list and then outputs it back into the file. This can be made faster by processing the raw text and appending commas at the end of the line. However, this optimization can be done at a later stage if needed. 

If the value of a key in tabular was not updated, the value persists from the previous iteration. This can be considered an error if the user didn't intend to log the same information multiple times. The user can now call tabular.delete_key or tabular.delete_all at the end of a iteration. This will clear the dictionary in the tabular class. In the next iteration if the same key isn't recorded, then it would be set as blank, which is more intuitive and natural. 

When opening the file, we are using the mode w+. This allows you to read and write at the same time without having to close the file. 

Also added an example file to test the feature in examples/bugtest.py. I wasn't what the correct place to put the test file was at. Could you let me know how to improve this?
 @avnishn @zequnyu. 
